### PR TITLE
Add debug msg to assertion in python node.handle

### DIFF
--- a/samples/python/node.py
+++ b/samples/python/node.py
@@ -91,7 +91,11 @@ class Node(object):
     def handle(self, msg_frames):
 
         # Unpack the message frames.
-        assert len(msg_frames) == 3
+        # in the event of a mismatch, format a nice string with msg_frames in
+        # the raw, for debug purposes
+        assert len(msg_frames) == 3, ((
+            "Multipart ZMQ message had wrong length. "
+            "Full message contents:\n{}").format(msg_frames))
         assert msg_frames[0] == self.name
         # Second field is the empty delimiter
         msg = json.loads(msg_frames[2])


### PR DESCRIPTION
@borjasotomayor
Several students came to office hours with the error reported in https://piazza.com/class/im57kwtezvv35m
Since we haven't been able to reproduce, I'd like to offer them a new version to run which might help us track down the error.

I think that what's happening is that pyZMQ's `zmq.eventloop.future.Socket.recv_multipart` method is actually packing multiple messages together in its result, and handing that to the callback.
I think the fix _might_ be to assert that `len(msg_frames) % 3 == 0`, and then unpack it 3 parts at a time.

My commit message has details on the change itself.
