### PR TITLE
Update README to specify usage of pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First, clone chistributed into any directory you want:
 
 Inside the chistributed directory, run the following:
 
-    pip install --user -e .
+    pip3 install --user -e .
 
 Finally, change your $PATH (you may want to include this in your `.bashrc`
 file to make sure it gets set correctly every time you log in:


### PR DESCRIPTION
The README file says to use pip, but on the UChicago CSIL machines pip defaults to Python2.7. This has caused issues with import of `zmq.eventloop` for a few people in this quarters ADS class. Installing with pip3 rather than pip fixes the issue.

As such, this PR updates the README file to specify pip3 usage rather than pip usage.