### PR TITLE
Add egg files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *~
+.eggs
+src/chistributed.egg-info


### PR DESCRIPTION
We're using `chistributed` as a submodule:
```
$ virtualenv -p python3 venv
$ source venv/bin/activate
$ pip install -e chistributed
```
After running these steps, two new directories full of files get created in the `chistributed` directory, resulting in a dirty repo state (`git status` warns about untracked content in the submodule). This commit adds those directories to the `.gitignore`.