### PR TITLE
Force setup.py to install old version of cmd2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name='chistributed',
                            "tornado >= 5.0.2",
                            "click >= 5.1",
                            "pyyaml >= 3.11",
-                           "cmd2 >= 0.8.5",
+                           "cmd2 == 0.8.7",
                            "colorama >= 0.3.9"
                          ],
       setup_requires = [ "setuptools_git >= 1.0" ],


### PR DESCRIPTION
The latest version of cmd2 removes the options decorator which causes chistributed to crash on start. Forcing the older version to install fixes this issue.