### PR TITLE
Change hello request destination from list

### DIFF
--- a/src/chistributed/backends/zmq.py
+++ b/src/chistributed/backends/zmq.py
@@ -253,7 +253,7 @@ class ZMQBackend:
         self.pub_lock.release()
 
     def __hello_callback(self, node_id):
-        zmq_msg = ZMQMessage(node_id, {'type': 'hello', 'destination': [node_id]})
+        zmq_msg = ZMQMessage(node_id, {'type': 'hello', 'destination': node_id})
         
         def callback():
             def hello_sender(tries_left):


### PR DESCRIPTION
This PR is based on [this discussion](https://github.com/uchicago-cs/chiwebsite/pull/2).

It simply changes the destination type on a form a singleton list to the node name on broker "hello" messages. 

There should be not other changes required in sample code, etc., because as far as I can tell, none of it checked the destination field. It also should be unlikely to break existing implementations, since there's no reason I can think of to check the destination field on a "hello" message.

Edit: I should also mention that I've tested this against our project implementation and against the sample python code, but didn't think of anything else.